### PR TITLE
stop sepp after placements are computed

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@ from setuptools import setup
 from setuptools.command.install import install
 import tarfile
 import subprocess
+import os
 
 __version__ = "1.0.3"
 
@@ -34,6 +35,11 @@ classes = """
 def _config_sepp(assets_dir):
     subprocess.run(['python', 'setup.py', 'config', '-c'], check=True,
                    cwd=assets_dir + '/sepp-package/sepp')
+
+
+def _patch_sepp(assets_dir, name_patch):
+    subprocess.run(['patch', 'sepp-package/run-sepp.sh', name_patch],
+                   check=True, cwd=assets_dir)
 
 
 def _initial():
@@ -101,6 +107,13 @@ class PostInstallCommand(install):
         # LEAVING AS WE MIGHT NEED IT IN THE FUTURE
         # shutil.copy('taxonomy_gg99.qza', assets_dir)
 
+        # copy patch file
+        name_patch = 'onlyplacements.patch'
+        shutil.copy(os.path.join('support_files', 'sepp', name_patch),
+                    assets_dir)
+
+        self.execute(_patch_sepp, [assets_dir, name_patch],
+                     'Patch run-sepp.sh')
         self.execute(_config_sepp, [assets_dir], 'Configuring SEPP')
 
 

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,6 @@ from setuptools import setup
 from setuptools.command.install import install
 import tarfile
 import subprocess
-import os
 
 __version__ = "1.0.3"
 

--- a/support_files/sepp/onlyplacements.patch
+++ b/support_files/sepp/onlyplacements.patch
@@ -1,0 +1,48 @@
+--- run-sepp.sh	2017-12-07 13:44:13.124241203 -0800
++++ run-sepp-stefan.sh	2017-12-07 13:44:05.076362969 -0800
+@@ -1,7 +1,7 @@
+ #!/bin/bash  
+ 
+ if [ $# -lt 2 ]; then
+-   echo USAGE: $0 "[input fragments file] [output prefix] [optional: -x number-of-cores ] [optional: -A alignment subset size] [optional: -P placement subset size] [optional: any other SEPP argument] [optional: -t filename reference phylogeny] [optional: -a filename reference alignment]
++   echo USAGE: $0 "[input fragments file] [output prefix] [optional: -x number-of-cores ] [optional: -A alignment subset size] [optional: -P placement subset size] [optional: any other SEPP argument] [optional: -t filename reference phylogeny] [optional: -a filename reference alignment] [optional: -n 1 = no tree-, just placements- computation]
+    Optional commands need not be in order. Any SEPP option can also be passed. For example, use
+    -x 8
+    to make SEPP us 8 threads"
+@@ -76,6 +76,10 @@
+ 			t="$2"
+ 			shift # past argument
+ 			;;
++		-n|--noTreeComputation)
++			noTree="$2"
++			shift # past argument
++			;;
+ 		*)
+ 			opts="$opts"" ""$key"" ""$2"
+ 			shift # past argument
+@@ -111,14 +115,20 @@
+ cp $tmp/${name}_placement.json .
+ cp $tmp/${name}_rename-json.py .
+ 
+-gbin=$( dirname `grep -A1 "pplacer" $DIR/sepp/.sepp/main.config |grep path|sed -e "s/^path=//g"` )
++# we might want to split computation in two parts: a) obtaining placements and b) creation of an insertion tree.
++# If -n set to something, we stop after a) and leave it to the user to compute b) afterwards.
++if [ -z ${noTree+x} ]; then
++	gbin=$( dirname `grep -A1 "pplacer" $DIR/sepp/.sepp/main.config |grep path|sed -e "s/^path=//g"` )
+ 
+-$gbin/guppy tog ${name}_placement.json
++	$gbin/guppy tog ${name}_placement.json
+ 
+-cat ${name}_placement.tog.tre | python ${name}_rename-json.py > ${name}_placement.tog.relabelled.tre
++	cat ${name}_placement.tog.tre | python ${name}_rename-json.py > ${name}_placement.tog.relabelled.tre
+ 
+-$gbin/guppy tog --xml ${name}_placement.json
++	$gbin/guppy tog --xml ${name}_placement.json
+ 
+-cat ${name}_placement.tog.xml | python ${name}_rename-json.py > ${name}_placement.tog.relabelled.xml
++	cat ${name}_placement.tog.xml | python ${name}_rename-json.py > ${name}_placement.tog.relabelled.xml
++else
++	echo "User requested skipping of insertion tree computation. Only placements are returned.";
++fi;
+ 
+ echo output files are at ${name}_placement.* and more files are at $tmp . Consider removing $tmp if its files are not needed. 


### PR DESCRIPTION
This patch allows sepp to stop execution after placements are computed, i.e. the insertion tree via guppy is not computed.
We need this behaviour for Qiita, where we want to separate placement and tree computation.