### PR TITLE
remove SEPP installation, because it is handled by conda

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,9 +9,6 @@
 # -----------------------------------------------------------------------------
 
 from setuptools import setup
-from setuptools.command.install import install
-import tarfile
-import subprocess
 
 __version__ = "1.0.3"
 
@@ -27,93 +24,6 @@ classes = """
     Operating System :: POSIX :: Linux
     Operating System :: MacOS :: MacOS X
 """
-
-# configuration taken from: https://github.com/biocore/q2-fragment-insertion
-
-
-def _config_sepp(assets_dir):
-    subprocess.run(['python', 'setup.py', 'config', '-c'], check=True,
-                   cwd=assets_dir + '/sepp-package/sepp')
-
-
-def _patch_sepp(assets_dir, name_patch):
-    subprocess.run(['patch', 'sepp-package/run-sepp.sh', name_patch],
-                   check=True, cwd=assets_dir)
-
-
-def _initial():
-    import shutil
-
-    if shutil.which('java') is None:
-        raise ValueError('java not found')
-
-    result = subprocess.run(['java', '-version'], stdout=subprocess.PIPE,
-                            stderr=subprocess.PIPE)
-    err_content = result.stderr.decode('ascii')
-    if ('java version' not in err_content) and \
-       ('jdk version' not in err_content):
-        raise ValueError(('Please verify that java is installed and working. '
-                          'As a first test, please execute "java -version" '
-                          'and make sure the output shows there is an actual '
-                          'version installed. OSX lies. If Java needs to be '
-                          'installed, please obtain the 1.8 or greater Java '
-                          'Runtime Environment (JRE) from Oracle.com. A '
-                          'google search for "download jre" is likely to be '
-                          'sufficient.'))
-
-
-class PostInstallCommand(install):
-    """Post-installation for installation mode."""
-    def run(self):
-        import urllib.request
-        import shutil
-        import os
-
-        _initial()
-        install.run(self)
-
-        # using a tagged version from Siavash's repo
-        git_tag = '4.3.4b'
-        src_url = ('https://github.com/smirarab/sepp-refs/archive/%s.tar.gz' %
-                   git_tag)
-
-        assets_dir = os.path.join(self.install_libbase,
-                                  'assets/')
-
-        if not os.path.exists(assets_dir):
-            os.mkdir(assets_dir)
-
-        out_f = 'tagged-sepp-package.tar.gz'
-        # 1/3: download git tagged version sources ...
-        with urllib.request.urlopen(
-                src_url) as response, open(out_f, 'wb') as out:
-            shutil.copyfileobj(response, out)
-
-        # 2/3: ... which come as one tar archive that needs to be extracted ...
-        opened = tarfile.open(out_f, "r:gz")
-        opened.extractall(path=self.install_libbase)
-        opened.close()
-
-        # 3/3: ... and contains another tar archive which is extracted here.
-        opened = tarfile.open(os.path.join(self.install_libbase,
-                                           'sepp-refs-%s' % git_tag,
-                                           'gg', 'sepp-package.tar.bz'),
-                              "r:bz2")
-        opened.extractall(path=assets_dir)
-        opened.close()
-
-        # copy default taxonomy Greengenes 99%: OTU-ID to lineage
-        # LEAVING AS WE MIGHT NEED IT IN THE FUTURE
-        # shutil.copy('taxonomy_gg99.qza', assets_dir)
-
-        # copy patch file
-        name_patch = 'onlyplacements.patch'
-        shutil.copy(os.path.join('support_files', 'sepp', name_patch),
-                    assets_dir)
-
-        self.execute(_patch_sepp, [assets_dir, name_patch],
-                     'Patch run-sepp.sh')
-        self.execute(_config_sepp, [assets_dir], 'Configuring SEPP')
 
 
 with open('README.rst') as f:
@@ -135,7 +45,6 @@ setup(name='qp-deblur',
       extras_require={'test': ["nose >= 0.10.1", "pep8"]},
       install_requires=['click >= 3.3', 'future', 'deblur'],
       dependency_links=[
-        ('https://github.com/qiita-spots/qiita-files/archive/master.zip#'
-         'egg=qiita-files-0.1.0-dev')],
-      classifiers=classifiers,
-      cmdclass={'install': PostInstallCommand})
+          ('https://github.com/qiita-spots/qiita-files/archive/master.zip#'
+           'egg=qiita-files-0.1.0-dev')],
+      classifiers=classifiers)


### PR DESCRIPTION
I don't know how that could happen but we currently install SEPP via conda AND the setup.py