### PR TITLE
add *all* fragments if one placement holds multiple labels=fragments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ install:
   - conda create --quiet --yes -n deblur-1.1.0 python=3.5 pip
   - source activate deblur-1.1.0
   - export QIITA_SERVER_CERT=$HOME/miniconda3/envs/qiita/lib/python3.6/site-packages/qiita_core/support_files/server.crt
-  - conda install --quiet --yes -c bioconda -c biocore "VSEARCH=2.7.0" MAFFT=7.310 SortMeRNA=2.0 fragment-insertion numpy cython
+  - conda install --quiet --yes -c bioconda -c biocore "VSEARCH=2.7.0" MAFFT=7.310 SortMeRNA=2.0 fragment-insertion numpy==1.13.0 cython
   - pip install -U pip
   - pip install coveralls flake8
   - travis_retry pip install .

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,6 @@ before_script:
   - cat /tmp/supervisord.log
 script:
   - source activate deblur-1.1.0
-  - start_deblur "https://localhost:8383" register ignored
   - nosetests --with-doctest --with-coverage --cover-package=qp_deblur
   - flake8 qp_deblur setup.py scripts support_files/patches/*.py support_files/sepp/*.py
 addons:

--- a/qp_deblur/deblur.py
+++ b/qp_deblur/deblur.py
@@ -143,7 +143,9 @@ def generate_sepp_placements(seqs, out_dir, threads, reference_phylogeny=None,
     if exists(file_placements):
         with open(file_placements, 'r') as fh_placements:
             plcmnts = json.loads(fh_placements.read())
-            return {p['nm'][0][0]: p['p'] for p in plcmnts['placements']}
+            return {seqlbl[0]: p['p']
+                    for p in plcmnts['placements']
+                    for seqlbl in p['nm']}
     else:
         # due to the wrapper style of run-sepp.sh the actual exit code is never
         # returned and we have no way of finding out which sub-command failed


### PR DESCRIPTION
I found that SEPP sometimes "merges" multiple fragments and returns one placements for those instead of one placement for each fragment. This is in general supported by the placement data format (see section "Placements." in https://journals.plos.org/plosone/article?id=10.1371/journal.pone.0031009).

I found that is actually used by SEPP when running SEPP (outside of qiita) on artefact 103122 of study 13434. This happened multiple times. Here is a histogram (i.e. in 39401 cases, a fragment sequence comes with its individual placement, but 1790 times, two sequences share the same placement, 381 times three fragments belong to the same placement, ...):
1     39401
2      1790
3       381
4       148
5        71
6        57
7        33
8        21
10       15
9        12
11       10
12        6
13        5
14        3
15        2
16        2
19        2
27        2
29        1
22        1
23        1
24        1
31        1

Here is one example from the run with all 46642 fragments:
```
{'p': [[367293, -6369.8076, 0.30783, 5.8344317e-06, 1.7834547],
   [367960, -6370.0044, 0.25284433, 7.768066e-06, 1.9376909],
   [365868, -6370.8423, 0.10938823, 0.0026485485, 1.9999927],
   [364404, -6370.883, 0.10504965, 5.6102604e-06, 1.9999927],
   [367013, -6370.9854, 0.094813086, 6.91318e-06, 1.9968519],
   [367661, -6371.3086, 0.06862929, 5.8844803e-06, 1.9978131],
   [366164, -6371.419, 0.061445408, 7.1577597e-06, 1.9999927]],
  'nm': [['CCGCCAATTTCTTTGAGTTTTAGCCTTGCGGCCGTACTCCCCAGGCGGGGCGCTTAATGCGTTAGCTGCGGCACGGAACTCGTGGAATGAGTCCCACACCTAGCGCCCAACGTTTACGGCATGGACTACCAGGGTATCTAATCCTGTTCG',
    1],
   ['CCGCCAATTTATTTGAGTTTTAGCCTTGCGGCCGTACTCCCCAGGCGGGGCGCTTAATGCGTTAGCTGCGGCACGGAACTCGTGGAATGAGTCCCACACCTAGCGCCCAACGTTTACGGCATGGACTACCAGGGTATCTAATCCTGTTTG',
    1],
   ['CCGCCAATTTATTTGAGTTTTAGCCTTGCGGCCGTACTCCCCAGGCGGGGCGCTTAATGCGTTAGCTGCGGCACGGAACTCGTGGAATGAGTCCCACACCTAGCGCCCAACGTTTACGGCATGGACTACCAGGGTATCTAATCCTGTTCG',
    1]]}
```

Interestingly, when running SEPP with only these three fragments, results differ. Namely the resulting placement file is (without the tree)
```
{
  "tree": "",
  "placements": [{
      "p": [[367293, -6369.8076, 0.30783, 0.0000058344317, 1.7834547],
        [367960, -6370.0044, 0.25284433, 0.000007768066, 1.9376909],
        [365868, -6370.8423, 0.10938823, 0.0026485485, 1.9999927],
        [364404, -6370.883, 0.10504965, 0.0000056102604, 1.9999927],
        [367013, -6370.9854, 0.094813086, 0.00000691318, 1.9968519],
        [367661, -6371.3086, 0.06862929, 0.0000058844803, 1.9978131],
        [366164, -6371.419, 0.061445408, 0.0000071577597, 1.9999927]],
      "nm": [["CCGCCAATTTATTTGAGTTTTAGCCTTGCGGCCGTACTCCCCAGGCGGGGCGCTTAATGCGTTAGCTGCGGCACGGAACTCGTGGAATGAGTCCCACACCTAGCGCCCAACGTTTACGGCATGGACTACCAGGGTATCTAATCCTGTTCG",
          1]]
    },
    {
      "p": [[367293, -6369.8076, 0.30783, 0.0000058344317, 1.7834547],
        [367960, -6370.0044, 0.25284433, 0.000007768066, 1.9376909],
        [365868, -6370.8423, 0.10938823, 0.0026485485, 1.9999927],
        [364404, -6370.883, 0.10504965, 0.0000056102604, 1.9999927],
        [367013, -6370.9854, 0.094813086, 0.00000691318, 1.9968519],
        [367661, -6371.3086, 0.06862929, 0.0000058844803, 1.9978131],
        [366164, -6371.419, 0.061445408, 0.0000071577597, 1.9999927]],
      "nm": [["CCGCCAATTTATTTGAGTTTTAGCCTTGCGGCCGTACTCCCCAGGCGGGGCGCTTAATGCGTTAGCTGCGGCACGGAACTCGTGGAATGAGTCCCACACCTAGCGCCCAACGTTTACGGCATGGACTACCAGGGTATCTAATCCTGTTTG",
          1]]
    },
    {
      "p": [[367293, -6369.8076, 0.30783, 0.0000058344317, 1.7834547],
        [367960, -6370.0044, 0.25284433, 0.000007768066, 1.9376909],
        [365868, -6370.8423, 0.10938823, 0.0026485485, 1.9999927],
        [364404, -6370.883, 0.10504965, 0.0000056102604, 1.9999927],
        [367013, -6370.9854, 0.094813086, 0.00000691318, 1.9968519],
        [367661, -6371.3086, 0.06862929, 0.0000058844803, 1.9978131],
        [366164, -6371.419, 0.061445408, 0.0000071577597, 1.9999927]],
      "nm": [["CCGCCAATTTCTTTGAGTTTTAGCCTTGCGGCCGTACTCCCCAGGCGGGGCGCTTAATGCGTTAGCTGCGGCACGGAACTCGTGGAATGAGTCCCACACCTAGCGCCCAACGTTTACGGCATGGACTACCAGGGTATCTAATCCTGTTCG",
          1]]
    }],
  "metadata": {
    "invocation": "SEPP-generated json file (sepp 2)."
  },
  "version": 1, "fields": ["edge_num",
    "likelihood",
    "like_weight_ratio",
    "distal_length",
    "pendant_length"]
}
```
Thus, coming up with a quick test isn't easy.

When dumping the computed placement information, we use the fragment sequence as key. However, I did not iterate through those multiple sequences and falsely took only the first - instead of all. Thus, we do not save all computed fragment placements in the qiita DB and thus have to re-compute too many fragments when re-running SEPP (for the same artefact or others).

I think this PR should fix the issue simply by iterating through all placements and within each placement through all labels, aka fragment sequences.