### PR TITLE
Uncouple plugins

### DIFF
--- a/.github/workflows/qiita-plugin-ci.yml
+++ b/.github/workflows/qiita-plugin-ci.yml
@@ -50,9 +50,8 @@ jobs:
 
           # we need to download qiita directly so we have "easy" access to
           # all config files
-          # wget https://github.com/biocore/qiita/archive/dev.zip
-          # unzip dev.zip
-          git clone -b uncouplePlugins https://github.com/jlab/qiita.git qiita-dev
+          wget https://github.com/biocore/qiita/archive/dev.zip
+          unzip dev.zip
 
           # pull out the port so we can modify the configuration file easily
           pgport=${{ job.services.postgres.ports[5432] }}
@@ -80,9 +79,6 @@ jobs:
           conda activate deblur
           conda install --quiet --yes -c bioconda -c biocore "VSEARCH=2.7.0" MAFFT=7.310 SortMeRNA=2.0 fragment-insertion gcc
           conda install --quiet --yes -c conda-forge -c bioconda scikit-bio==0.5.5 pandas
-
-          git clone -b uncouplePlugins https://github.com/jlab/qiita_client.git qiita_client
-          cd qiita_client && pip install . && cd ..
 
           export QIITA_ROOTCA_CERT=`pwd`/qiita-dev/qiita_core/support_files/ci_rootca.crt
           export QIITA_CONFIG_FP=`pwd`/qiita-dev/qiita_core/support_files/config_test_local.cfg

--- a/.github/workflows/qiita-plugin-ci.yml
+++ b/.github/workflows/qiita-plugin-ci.yml
@@ -50,8 +50,9 @@ jobs:
 
           # we need to download qiita directly so we have "easy" access to
           # all config files
-          wget https://github.com/biocore/qiita/archive/dev.zip
-          unzip dev.zip
+          # wget https://github.com/biocore/qiita/archive/dev.zip
+          # unzip dev.zip
+          git clone -b uncouplePlugins https://github.com/jlab/qiita.git qiita-dev
 
           # pull out the port so we can modify the configuration file easily
           pgport=${{ job.services.postgres.ports[5432] }}
@@ -79,6 +80,9 @@ jobs:
           conda activate deblur
           conda install --quiet --yes -c bioconda -c biocore "VSEARCH=2.7.0" MAFFT=7.310 SortMeRNA=2.0 fragment-insertion gcc
           conda install --quiet --yes -c conda-forge -c bioconda scikit-bio==0.5.5 pandas
+
+          git clone -b uncouplePlugins https://github.com/jlab/qiita_client.git qiita_client
+          cd qiita_client && pip install . && cd ..
 
           export QIITA_ROOTCA_CERT=`pwd`/qiita-dev/qiita_core/support_files/ci_rootca.crt
           export QIITA_CONFIG_FP=`pwd`/qiita-dev/qiita_core/support_files/config_test_local.cfg
@@ -113,6 +117,7 @@ jobs:
           export NGINX_FILE=`pwd`/qiita-dev/qiita_pet/nginx_example.conf
           export NGINX_FILE_NEW=`pwd`/qiita-dev/qiita_pet/nginx_example_local.conf
           sed "s#/home/runner/work/qiita/qiita#${PWD}/qiita-dev/#g" ${NGINX_FILE} > ${NGINX_FILE_NEW}
+          sed -i "s#/Users/username/qiita#${PWD}/qiita-dev#g" ${NGINX_FILE_NEW}
           nginx -c ${NGINX_FILE_NEW}
 
           echo "3. Setting up qiita"

--- a/.github/workflows/qiita-plugin-ci.yml
+++ b/.github/workflows/qiita-plugin-ci.yml
@@ -94,7 +94,7 @@ jobs:
           sed -i "s/f'Entered BaseQiitaPlugin._register_command({command.name})'/'Entered BaseQiitaPlugin._register_command(%s)' % command.name/"  $CONDA_PREFIX/lib/python3.5/site-packages/qiita_client/plugin.py
           pip --quiet install coveralls
 
-          configure_deblur --env-script "source /home/runner/.profile; conda activate deblur" --server-cert $QIITA_ROOTCA_CERT --plugin-coupling filesystem
+          configure_deblur --env-script "source /home/runner/.profile; conda activate deblur" --server-cert $QIITA_ROOTCA_CERT filesystem
 
           echo "Available Qiita plugins"
           ls ~/.qiita_plugins/

--- a/.github/workflows/qiita-plugin-ci.yml
+++ b/.github/workflows/qiita-plugin-ci.yml
@@ -94,7 +94,7 @@ jobs:
           sed -i "s/f'Entered BaseQiitaPlugin._register_command({command.name})'/'Entered BaseQiitaPlugin._register_command(%s)' % command.name/"  $CONDA_PREFIX/lib/python3.5/site-packages/qiita_client/plugin.py
           pip --quiet install coveralls
 
-          configure_deblur --env-script "source /home/runner/.profile; conda activate deblur" --server-cert $QIITA_ROOTCA_CERT
+          configure_deblur --env-script "source /home/runner/.profile; conda activate deblur" --server-cert $QIITA_ROOTCA_CERT --plugin-coupling filesystem
 
           echo "Available Qiita plugins"
           ls ~/.qiita_plugins/

--- a/qp_deblur/deblur.py
+++ b/qp_deblur/deblur.py
@@ -428,7 +428,8 @@ def deblur(qclient, job_id, parameters, out_dir):
     # Getting preparation information
     prep_info = qclient.get(
         '/qiita_db/prep_template/%s/' % artifact_info['prep_information'][0])
-    df = pd.read_csv(qclient.fetch_file_from_central(prep_info['prep-file']), sep='\t')
+    df = pd.read_csv(
+        qclient.fetch_file_from_central(prep_info['prep-file']), sep='\t')
     if prep_info['data_type'] not in {'16S', '18S', 'ITS'}:
         error_msg = ('deblur was developed only for amplicon sequencing data')
         return False, None, error_msg
@@ -456,8 +457,9 @@ def deblur(qclient, job_id, parameters, out_dir):
         # using the same number of parallel jobs as defined by the command
         n_jobs = int(parameters['Jobs to start'])
         # [0] cause there should be only 1 file
-        to_per_sample_files(qclient.fetch_file_from_central(fps['preprocessed_demux'][0]),
-                            out_dir=split_out_dir, n_jobs=n_jobs)
+        to_per_sample_files(
+            qclient.fetch_file_from_central(fps['preprocessed_demux'][0]),
+            out_dir=split_out_dir, n_jobs=n_jobs)
 
         qclient.update_job_step(job_id, "Step 2 of 4: Generating per sample "
                                 "from demux (2/2)")
@@ -467,8 +469,10 @@ def deblur(qclient, job_id, parameters, out_dir):
     else:
         qclient.update_job_step(job_id, "Step 2 of 4: Generating deblur "
                                 "command")
-        cmd = generate_deblur_workflow_commands(list(map(qclient.fetch_file_from_central, fps['preprocessed_fastq'])),
-                                                out_dir, parameters)
+        cmd = generate_deblur_workflow_commands(
+            list(map(qclient.fetch_file_from_central,
+                     fps['preprocessed_fastq'])),
+            out_dir, parameters)
 
     # Step 3 execute deblur
     qclient.update_job_step(job_id, "Step 3 of 4: Executing deblur job")
@@ -582,14 +586,23 @@ def deblur(qclient, job_id, parameters, out_dir):
     else:
         new_placements = None
 
-    ainfo = [ArtifactInfo('deblur final table', 'BIOM',
-                          [(qclient.push_file_to_central(final_biom), 'biom'),
-                           (qclient.push_file_to_central(final_seqs), 'preprocessed_fasta')])]
+    ainfo = [
+        ArtifactInfo(
+            'deblur final table', 'BIOM',
+            [(qclient.push_file_to_central(final_biom),
+              'biom'),
+             (qclient.push_file_to_central(final_seqs),
+              'preprocessed_fasta')])]
     if fp_phylogeny is not None:
-        ainfo.append(ArtifactInfo('deblur reference hit table', 'BIOM',
-                     [(qclient.push_file_to_central(final_biom_hit), 'biom'),
-                      (qclient.push_file_to_central(final_seqs_hit), 'preprocessed_fasta'),
-                      (qclient.push_file_to_central(fp_phylogeny), 'plain_text')], new_placements))
+        ainfo.append(
+            ArtifactInfo(
+                'deblur reference hit table', 'BIOM',
+                [(qclient.push_file_to_central(final_biom_hit),
+                  'biom'),
+                 (qclient.push_file_to_central(final_seqs_hit),
+                  'preprocessed_fasta'),
+                 (qclient.push_file_to_central(fp_phylogeny),
+                  'plain_text')], new_placements))
 
     return True, ainfo, ""
 

--- a/qp_deblur/deblur.py
+++ b/qp_deblur/deblur.py
@@ -428,7 +428,7 @@ def deblur(qclient, job_id, parameters, out_dir):
     # Getting preparation information
     prep_info = qclient.get(
         '/qiita_db/prep_template/%s/' % artifact_info['prep_information'][0])
-    df = pd.read_csv(prep_info['prep-file'], sep='\t')
+    df = pd.read_csv(qclient.fetch_file_from_central(prep_info['prep-file']), sep='\t')
     if prep_info['data_type'] not in {'16S', '18S', 'ITS'}:
         error_msg = ('deblur was developed only for amplicon sequencing data')
         return False, None, error_msg
@@ -456,7 +456,7 @@ def deblur(qclient, job_id, parameters, out_dir):
         # using the same number of parallel jobs as defined by the command
         n_jobs = int(parameters['Jobs to start'])
         # [0] cause there should be only 1 file
-        to_per_sample_files(fps['preprocessed_demux'][0],
+        to_per_sample_files(qclient.fetch_file_from_central(fps['preprocessed_demux'][0]),
                             out_dir=split_out_dir, n_jobs=n_jobs)
 
         qclient.update_job_step(job_id, "Step 2 of 4: Generating per sample "
@@ -467,7 +467,7 @@ def deblur(qclient, job_id, parameters, out_dir):
     else:
         qclient.update_job_step(job_id, "Step 2 of 4: Generating deblur "
                                 "command")
-        cmd = generate_deblur_workflow_commands(fps['preprocessed_fastq'],
+        cmd = generate_deblur_workflow_commands(list(map(qclient.fetch_file_from_central, fps['preprocessed_fastq'])),
                                                 out_dir, parameters)
 
     # Step 3 execute deblur
@@ -583,13 +583,13 @@ def deblur(qclient, job_id, parameters, out_dir):
         new_placements = None
 
     ainfo = [ArtifactInfo('deblur final table', 'BIOM',
-                          [(final_biom, 'biom'),
-                           (final_seqs, 'preprocessed_fasta')])]
+                          [(qclient.push_file_to_central(final_biom), 'biom'),
+                           (qclient.push_file_to_central(final_seqs), 'preprocessed_fasta')])]
     if fp_phylogeny is not None:
         ainfo.append(ArtifactInfo('deblur reference hit table', 'BIOM',
-                     [(final_biom_hit, 'biom'),
-                      (final_seqs_hit, 'preprocessed_fasta'),
-                      (fp_phylogeny, 'plain_text')], new_placements))
+                     [(qclient.push_file_to_central(final_biom_hit), 'biom'),
+                      (qclient.push_file_to_central(final_seqs_hit), 'preprocessed_fasta'),
+                      (qclient.push_file_to_central(fp_phylogeny), 'plain_text')], new_placements))
 
     return True, ainfo, ""
 

--- a/qp_deblur/tests/test_archive.py
+++ b/qp_deblur/tests/test_archive.py
@@ -8,7 +8,7 @@
 
 import json
 from unittest import main
-from os import close, remove
+from os import close, remove, environ
 from shutil import copyfile, rmtree
 from tempfile import mkstemp, mkdtemp
 from json import dumps

--- a/qp_deblur/tests/test_archive.py
+++ b/qp_deblur/tests/test_archive.py
@@ -15,7 +15,6 @@ from json import dumps
 from os.path import exists, isdir
 
 from qiita_client.testing import PluginTestCase
-from qiita_client.plugin import BaseQiitaPlugin
 
 from qp_deblur import plugin
 from qp_deblur.deblur import deblur
@@ -64,11 +63,6 @@ class deblurTests(PluginTestCase):
             ('TACGGAGGGTGCAAGCGTTAATCGGAATTACTGGGCGTAAAGCGCACGTAGGCGGTTCGTTAAG'
              'CCAGCTGTGAAATCCCCGGGCTCAACCTGGGAATTG')
         ]
-
-        # as we access functions directly, plugin configuration is not parsed,
-        # thus resort to environment variable here
-        self.qclient._plugincoupling = environ.get(
-            'QIITA_PLUGINCOUPLING', BaseQiitaPlugin._DEFAULT_PLUGIN_COUPLINGS)
 
     def tearDown(self):
         for fp in self._clean_up_files:

--- a/qp_deblur/tests/test_archive.py
+++ b/qp_deblur/tests/test_archive.py
@@ -8,7 +8,7 @@
 
 import json
 from unittest import main
-from os import close, remove, environ
+from os import close, remove
 from shutil import copyfile, rmtree
 from tempfile import mkstemp, mkdtemp
 from json import dumps

--- a/qp_deblur/tests/test_archive.py
+++ b/qp_deblur/tests/test_archive.py
@@ -15,7 +15,7 @@ from json import dumps
 from os.path import exists, isdir
 
 from qiita_client.testing import PluginTestCase
-
+from qiita_client.plugin import BaseQiitaPlugin
 
 from qp_deblur import plugin
 from qp_deblur.deblur import deblur
@@ -64,6 +64,11 @@ class deblurTests(PluginTestCase):
             ('TACGGAGGGTGCAAGCGTTAATCGGAATTACTGGGCGTAAAGCGCACGTAGGCGGTTCGTTAAG'
              'CCAGCTGTGAAATCCCCGGGCTCAACCTGGGAATTG')
         ]
+
+        # as we access functions directly, plugin configuration is not parsed,
+        # thus resort to environment variable here
+        self.qclient._plugincoupling = environ.get(
+            'QIITA_PLUGINCOUPLING', BaseQiitaPlugin._DEFAULT_PLUGIN_COUPLINGS)
 
     def tearDown(self):
         for fp in self._clean_up_files:

--- a/qp_deblur/tests/test_deblur.py
+++ b/qp_deblur/tests/test_deblur.py
@@ -15,6 +15,7 @@ from os.path import exists, isdir, join
 from os import environ
 
 from qiita_client.testing import PluginTestCase
+from qiita_client.plugin import BaseQiitaPlugin
 
 from qp_deblur import plugin
 from qp_deblur.deblur import (
@@ -56,6 +57,11 @@ class deblurTests(PluginTestCase):
 
         # saving current value of PATH
         self.oldpath = environ['PATH']
+        
+        # as we access functions directly, plugin configuration is not parsed,
+        # thus resort to environment variable here
+        self.qclient._plugincoupling = environ.get(
+            'QIITA_PLUGINCOUPLING', BaseQiitaPlugin._DEFAULT_PLUGIN_COUPLINGS)
 
     def tearDown(self):
         # restore eventually changed PATH env var

--- a/qp_deblur/tests/test_deblur.py
+++ b/qp_deblur/tests/test_deblur.py
@@ -12,7 +12,6 @@ from shutil import copyfile, rmtree
 from tempfile import mkstemp, mkdtemp
 from json import dumps, load
 from os.path import exists, isdir, join
-from os import environ
 
 from qiita_client.testing import PluginTestCase
 from qiita_client.plugin import BaseQiitaPlugin
@@ -57,7 +56,7 @@ class deblurTests(PluginTestCase):
 
         # saving current value of PATH
         self.oldpath = environ['PATH']
-        
+
         # as we access functions directly, plugin configuration is not parsed,
         # thus resort to environment variable here
         self.qclient._plugincoupling = environ.get(

--- a/qp_deblur/tests/test_deblur.py
+++ b/qp_deblur/tests/test_deblur.py
@@ -7,7 +7,7 @@
 # -----------------------------------------------------------------------------
 
 from unittest import main
-from os import close, remove, chmod
+from os import close, remove, chmod, environ
 from shutil import copyfile, rmtree
 from tempfile import mkstemp, mkdtemp
 from json import dumps, load

--- a/qp_deblur/tests/test_deblur.py
+++ b/qp_deblur/tests/test_deblur.py
@@ -14,7 +14,6 @@ from json import dumps, load
 from os.path import exists, isdir, join
 
 from qiita_client.testing import PluginTestCase
-from qiita_client.plugin import BaseQiitaPlugin
 
 from qp_deblur import plugin
 from qp_deblur.deblur import (
@@ -56,11 +55,6 @@ class deblurTests(PluginTestCase):
 
         # saving current value of PATH
         self.oldpath = environ['PATH']
-
-        # as we access functions directly, plugin configuration is not parsed,
-        # thus resort to environment variable here
-        self.qclient._plugincoupling = environ.get(
-            'QIITA_PLUGINCOUPLING', BaseQiitaPlugin._DEFAULT_PLUGIN_COUPLINGS)
 
     def tearDown(self):
         # restore eventually changed PATH env var

--- a/scripts/configure_deblur
+++ b/scripts/configure_deblur
@@ -17,17 +17,14 @@ from qp_deblur import plugin
 @click.option('--env-script', prompt='Environment script',
               default='source activate qp-deblur')
 @click.option('--server-cert', prompt='Server certificate', default='None')
-@click.option('--plugin-coupling',
-              prompt=("Type of coupling of plugin to central for file "
-                      "exchange. Valid values are 'filesystem' and 'https'"),
-                      default='filesystem')
-def config(env_script, server_cert, plugin_coupling):
+@click.argument('plugincoupling', required=False, default='filesystem')
+def config(env_script, server_cert, plugincoupling):
     """Generates the Qiita configuration files"""
     if server_cert == 'None':
         server_cert = None
     plugin.generate_config(env_script, 'start_deblur',
                            server_cert=server_cert,
-                           plugin_coupling=plugin_coupling)
+                           plugin_coupling=plugincoupling)
 
 if __name__ == '__main__':
     config()

--- a/scripts/configure_deblur
+++ b/scripts/configure_deblur
@@ -17,13 +17,17 @@ from qp_deblur import plugin
 @click.option('--env-script', prompt='Environment script',
               default='source activate qp-deblur')
 @click.option('--server-cert', prompt='Server certificate', default='None')
-@click.option('--plugin-coupling', prompt="Type of coupling of plugin to central for file exchange. Valid values are 'filesystem' and 'https'", default='filesystem')
+@click.option('--plugin-coupling',
+              prompt=("Type of coupling of plugin to central for file "
+                      "exchange. Valid values are 'filesystem' and 'https'"),
+                      default='filesystem')
 def config(env_script, server_cert, plugin_coupling):
     """Generates the Qiita configuration files"""
     if server_cert == 'None':
         server_cert = None
     plugin.generate_config(env_script, 'start_deblur',
-                           server_cert=server_cert, plugincoupling=plugin_coupling)
+                           server_cert=server_cert,
+                           plugin_coupling=plugin_coupling)
 
 if __name__ == '__main__':
     config()

--- a/scripts/configure_deblur
+++ b/scripts/configure_deblur
@@ -17,12 +17,13 @@ from qp_deblur import plugin
 @click.option('--env-script', prompt='Environment script',
               default='source activate qp-deblur')
 @click.option('--server-cert', prompt='Server certificate', default='None')
-def config(env_script, server_cert):
+@click.option('--plugin-coupling', prompt="Type of coupling of plugin to central for file exchange. Valid values are 'filesystem' and 'https'", default='filesystem')
+def config(env_script, server_cert, plugin_coupling):
     """Generates the Qiita configuration files"""
     if server_cert == 'None':
         server_cert = None
     plugin.generate_config(env_script, 'start_deblur',
-                           server_cert=server_cert)
+                           server_cert=server_cert, plugincoupling=plugin_coupling)
 
 if __name__ == '__main__':
     config()


### PR DESCRIPTION
Finally picking up on https://github.com/qiita-spots/qiita/pull/3480 and https://github.com/qiita-spots/qiita_client/pull/57 **qp-deblur** is the first plugin for which I added according code to transfer necessary input files from qiita main to the plugin and processed results from plugin back to qiita main.

This is only important IF `BASE_DATA_DIR` is not shared between qiita main and plugin "containers".

Tests in such a scenario also pass, see: https://github.com/jlab/qiita-keycloak/actions/runs/17792493508/job/50576310107