### PR TITLE
add ability to uncouple qp-deblur filesystem

### DIFF
--- a/.github/workflows/qiita-plugin-ci.yml
+++ b/.github/workflows/qiita-plugin-ci.yml
@@ -116,6 +116,7 @@ jobs:
           export NGINX_FILE=`pwd`/qiita-dev/qiita_pet/nginx_example.conf
           export NGINX_FILE_NEW=`pwd`/qiita-dev/qiita_pet/nginx_example_local.conf
           sed "s#/home/runner/work/qiita/qiita#${PWD}/qiita-dev/#g" ${NGINX_FILE} > ${NGINX_FILE_NEW}
+          sed -i "s#/Users/username/qiita#${PWD}/qiita-dev#g" ${NGINX_FILE_NEW}
           nginx -c ${NGINX_FILE_NEW}
 
           echo "3. Setting up qiita"

--- a/scripts/configure_deblur
+++ b/scripts/configure_deblur
@@ -17,12 +17,14 @@ from qp_deblur import plugin
 @click.option('--env-script', prompt='Environment script',
               default='source activate qp-deblur')
 @click.option('--server-cert', prompt='Server certificate', default='None')
-def config(env_script, server_cert):
+@click.argument('plugincoupling', required=False, default='filesystem')
+def config(env_script, server_cert, plugincoupling):
     """Generates the Qiita configuration files"""
     if server_cert == 'None':
         server_cert = None
     plugin.generate_config(env_script, 'start_deblur',
-                           server_cert=server_cert)
+                           server_cert=server_cert,
+                           plugin_coupling=plugincoupling)
 
 if __name__ == '__main__':
     config()


### PR DESCRIPTION
Finally picking up on https://github.com/qiita-spots/qiita/pull/3480 and https://github.com/qiita-spots/qiita_client/pull/57 **qp-deblur** is the first plugin for which I added according code to transfer necessary input files from qiita main to the plugin and processed results from plugin back to qiita main.

This is only important IF `BASE_DATA_DIR` is not shared between qiita main and plugin "containers".
